### PR TITLE
Fix mermaid diagram width and height clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Follow this progressive path for the best learning experience:
 ### Core path
 
 ```mermaid
-%%{init: {'theme':'dark','flowchart': {'useMaxWidth': true, 'nodeSpacing': 140, 'rankSpacing': 80, 'diagramPadding': 12}}}%%
+%%{init: {'theme':'dark','flowchart': {'useMaxWidth': true, 'nodeSpacing': 100, 'rankSpacing': 60, 'diagramPadding': 20, 'htmlLabels': true, 'wrappingWidth': 150}}}%%
 flowchart LR
-        F[Foundation<br/><small>Capability Model</small>] --> M[Methodology<br/><small>Decision Framework</small>] --> C[Context<br/><small>Scenarios</small>] --> A[Assessment<br/><small>Evaluation Criteria</small>] --> E[Execution<br/><small>Implementation Patterns</small>] --> D[Deep Dive<br/><small>Technologies</small>] --> MS[Mastery<br/><small>Feature Comparison</small>]
+        F["Foundation<br><small>Capability Model</small>"] --> M["Methodology<br><small>Decision Framework</small>"] --> C["Context<br><small>Scenarios</small>"] --> A["Assessment<br><small>Evaluation Criteria</small>"] --> E["Execution<br><small>Implementation Patterns</small>"] --> D["Deep Dive<br><small>Technologies</small>"] --> MS["Mastery<br><small>Feature Comparison</small>"]
 
         click F "{{ site.baseurl }}/docs/capability-model" "Open Capability Model" _self
         click M "{{ site.baseurl }}/docs/decision-framework" "Open Decision Framework" _self
@@ -82,12 +82,12 @@ flowchart LR
 
 {: .fs-4 .fw-300 }
 
-### Reference aids (use anytime)
+### Reference aids
 
 ```mermaid
-%%{init: {'theme':'dark','flowchart': {'useMaxWidth': true, 'nodeSpacing': 140, 'rankSpacing': 80, 'diagramPadding': 12}}}%%
+%%{init: {'theme':'dark','flowchart': {'useMaxWidth': true, 'nodeSpacing': 100, 'rankSpacing': 60, 'diagramPadding': 20}}}%%
 flowchart LR
-        VF[Visual Framework] --- QR[Quick Reference] --- RES[Resources] --- GLOS[Glossary]
+        VF["Visual Framework"] --- QR["Quick Reference"] --- RES["Resources"] --- GLOS["Glossary"]
 
         style VF fill:#5C2D91,stroke:#3B1D61,color:#fff
         style QR fill:#5C2D91,stroke:#3B1D61,color:#fff

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -21,22 +21,31 @@
 }
 
 .main-content .mermaid {
-  width: 100vw !important; // span full viewport width
+  width: calc(100vw - 200px) !important; // viewport minus sidebar and padding
   max-width: none !important;
   display: block !important;
-  margin: 0 auto !important;
-  position: relative !important;
-  left: 50% !important;
-  transform: translateX(-50%) !important; // center after expanding to viewport width
+  margin: 0 !important;
+  margin-left: -1rem !important; // offset the main-content padding
+  padding: 1rem 0 !important;
+  overflow-x: auto !important;
+  overflow-y: visible !important; // allow vertical content to show
 }
 
 .main-content .mermaid > svg {
-  width: 100vw !important;
+  width: 100% !important;
   max-width: none !important; // override inline px max-width from Mermaid renderer
   height: auto !important;
-  left: 50% !important;
-  transform: translateX(-50%) !important;
-  position: relative !important;
+  min-height: 120px !important; // ensure minimum height for multi-line nodes
+  display: block !important;
+}
+
+// Override Mermaid's inline viewBox clipping on flowchart nodes
+.main-content .mermaid svg .node rect {
+  overflow: visible !important;
+}
+
+.main-content .mermaid svg foreignObject {
+  overflow: visible !important;
 }
 // Custom styles to optimize layout for large monitors
 // Aggressive space utilization - minimize all padding and maximize content area


### PR DESCRIPTION
- CSS: Use calc(100vw - 200px) to account for sidebar width
- CSS: Add overflow-y visible and min-height for node content
- CSS: Override foreignObject overflow for proper text rendering
- README: Reduce nodeSpacing/rankSpacing, increase diagramPadding
- README: Add htmlLabels and wrappingWidth for better text handling
- README: Use quoted labels for consistent HTML parsing
- README: Remove 'use anytime' text from reference aids heading
