### PR TITLE
Remove useMaxWidth from Mermaid init, improve CSS width overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Follow this progressive path for the best learning experience:
 ### Core path
 
 ```mermaid
-%%{init: {'theme':'dark','flowchart': {'useMaxWidth': true, 'nodeSpacing': 100, 'rankSpacing': 60, 'diagramPadding': 20, 'htmlLabels': true, 'wrappingWidth': 150}}}%%
+%%{init: {'theme':'dark','flowchart': {'nodeSpacing': 100, 'rankSpacing': 60, 'diagramPadding': 20, 'htmlLabels': true}}}%%
 flowchart LR
         F["Foundation<br><small>Capability Model</small>"] --> M["Methodology<br><small>Decision Framework</small>"] --> C["Context<br><small>Scenarios</small>"] --> A["Assessment<br><small>Evaluation Criteria</small>"] --> E["Execution<br><small>Implementation Patterns</small>"] --> D["Deep Dive<br><small>Technologies</small>"] --> MS["Mastery<br><small>Feature Comparison</small>"]
 
@@ -85,7 +85,7 @@ flowchart LR
 ### Reference aids
 
 ```mermaid
-%%{init: {'theme':'dark','flowchart': {'useMaxWidth': true, 'nodeSpacing': 100, 'rankSpacing': 60, 'diagramPadding': 20}}}%%
+%%{init: {'theme':'dark','flowchart': {'nodeSpacing': 100, 'rankSpacing': 60, 'diagramPadding': 20}}}%%
 flowchart LR
         VF["Visual Framework"] --- QR["Quick Reference"] --- RES["Resources"] --- GLOS["Glossary"]
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -20,30 +20,40 @@
   border: 0 !important;
 }
 
-.main-content .mermaid {
-  width: calc(100vw - 200px) !important; // viewport minus sidebar and padding
-  max-width: none !important;
-  display: block !important;
-  margin: 0 !important;
-  margin-left: -1rem !important; // offset the main-content padding
-  padding: 1rem 0 !important;
-  overflow-x: auto !important;
-  overflow-y: visible !important; // allow vertical content to show
+// Force all Mermaid diagrams to 100% width - override inline styles from Mermaid renderer
+.mermaid {
+  width: 100% !important;
+  max-width: 100% !important;
 }
 
-.main-content .mermaid > svg {
+// Target SVG by ID pattern and class - Mermaid generates IDs like "mermaid-1234567890"
+svg[id^="mermaid-"],
+svg.flowchart,
+.mermaid svg {
   width: 100% !important;
-  max-width: none !important; // override inline px max-width from Mermaid renderer
+  max-width: 100% !important; // override Mermaid's inline max-width: NNNNpx
   height: auto !important;
-  min-height: 120px !important; // ensure minimum height for multi-line nodes
+  min-height: 120px !important;
   display: block !important;
+}
+
+.main-content .mermaid {
+  width: 100% !important;
+  max-width: 100% !important;
+  display: block !important;
+  margin: 0 !important;
+  padding: 1rem 0 !important;
+  overflow-x: auto !important;
+  overflow-y: visible !important;
 }
 
 // Override Mermaid's inline viewBox clipping on flowchart nodes
+.mermaid svg .node rect,
 .main-content .mermaid svg .node rect {
   overflow: visible !important;
 }
 
+.mermaid svg foreignObject,
 .main-content .mermaid svg foreignObject {
   overflow: visible !important;
 }


### PR DESCRIPTION
- Remove useMaxWidth from Mermaid flowchart configs (causes inline max-width)
- Remove wrappingWidth that's no longer needed
- Add global .mermaid selector with width/max-width 100% !important
- Target svg[id^='mermaid-'] to override inline max-width styles
- Let CSS fully control diagram width instead of Mermaid's calculations
