### PR TITLE
fix: Prevent SVG clipping on wide horizontal flowcharts

### DIFF
--- a/_includes/mermaid_config.js
+++ b/_includes/mermaid_config.js
@@ -15,7 +15,7 @@
     "clusterBkg": "#2d2d2d"
   },
   "flowchart": {
-    "useMaxWidth": true,
+    "useMaxWidth": false,
     "htmlLabels": true,
     "curve": "basis",
     "padding": 15,

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -2,12 +2,12 @@
 // MERMAID DIAGRAM STYLING
 // =============================================================================
 // Mermaid diagrams have different needs based on context:
-// - README/homepage: Simple horizontal flowcharts (LR) - compact height
+// - README/homepage: Simple horizontal flowcharts (LR) - may be wider than container
 // - Visual-framework: Complex vertical flowcharts (TD) - need full height
 // 
-// Strategy: Let Mermaid handle sizing via useMaxWidth, add scroll for overflow
+// Strategy: Let SVG render at natural size, container handles overflow with scroll
 
-// Base Mermaid container - minimal interference with Mermaid's native sizing
+// Base Mermaid container - allow scrolling for wide diagrams
 .mermaid {
   width: 100%;
   display: block;
@@ -16,11 +16,14 @@
   overflow-y: visible; // allow full height
 }
 
-// Mermaid SVG - let it size naturally, don't constrain
+// Mermaid SVG - DO NOT constrain width, let it render naturally
+// The container will scroll if SVG is wider than viewport
 .mermaid svg {
   display: block;
-  max-width: 100%; // prevent horizontal overflow
+  max-width: none !important; // CRITICAL: don't clip wide diagrams
+  width: auto !important; // natural width from viewBox
   height: auto; // natural height based on content
+  overflow: visible !important; // override user-agent overflow:hidden
 }
 
 // Pre/code blocks containing Mermaid - ensure proper display
@@ -43,6 +46,8 @@
   display: block;
   margin: 1rem 0;
   padding: 0.5rem 0;
+  overflow-x: auto;
+  overflow-y: visible;
 }
 
 // GitGraph specific styling
@@ -55,7 +60,7 @@
 // Ensure nodes and labels are visible
 .mermaid svg .node rect,
 .mermaid svg foreignObject {
-  overflow: visible;
+  overflow: visible !important;
 }
 // Custom styles to optimize layout for large monitors
 // Aggressive space utilization - minimize all padding and maximize content area


### PR DESCRIPTION
## Summary

Fix SVG clipping issue where the last node in horizontal flowcharts was being cut off.

## Problem

On the README page, both "Core path" and "Reference aids" diagrams had their rightmost nodes (Mastery/Feature Comparison and Glossary) cut off and invisible.

**Root Cause:**
- `max-width: 100%` on SVG was constraining the natural width
- Browser user-agent stylesheet applies `overflow: hidden` to SVG elements
- Combined effect: wide diagrams get clipped at container edge

## Solution

### CSS Changes (`_sass/custom/custom.scss`)
```css
.mermaid svg {
  max-width: none !important;  /* Don't clip wide diagrams */
  width: auto !important;      /* Use natural viewBox width */
  overflow: visible !important; /* Override UA overflow:hidden */
}
```

### Config Changes (`_includes/mermaid_config.js`)
- Changed `useMaxWidth: false` so Mermaid renders SVG at natural size
- Container handles overflow with horizontal scroll if needed

## Result

- Wide horizontal flowcharts (LR) now render completely
- All nodes visible including the last one
- If diagram is wider than viewport, container scrolls horizontally

## Testing

Verify on README that both flowcharts show all nodes, especially "Mastery" and "Glossary" on the right edge.