### PR TITLE
feat: expand SQL Server 2025 to full SQL Database Engine family

### DIFF
--- a/docs/decision-framework.md
+++ b/docs/decision-framework.md
@@ -207,7 +207,7 @@ Default to SaaS (built-in Copilot / Copilot Studio) when it meets the need; reac
 
 Separate how you ground answers from how you persist history or analytics.
 
-- **Grounding (RAG)** - Retrieve the right files or records per request (Microsoft Graph, Azure AI Search, Cosmos DB, PostgreSQL, SQL Server 2025). Use **Fabric Data Agents** for conversational analytics over OneLake. Standard agent setup provisions customer-owned Azure Storage, Azure AI Search, and Cosmos DB containers for thread data.[^standardsetup]
+- **Grounding (RAG)** - Retrieve the right files or records per request (Microsoft Graph, Azure AI Search, Cosmos DB, PostgreSQL, Azure SQL Database, Azure SQL MI, SQL Server 2025, SQL database in Fabric). Use **Fabric Data Agents** for conversational analytics over OneLake. Standard agent setup provisions customer-owned Azure Storage, Azure AI Search, and Cosmos DB containers for thread data.[^standardsetup]
 - **Memory** - Decide if conversations should persist (Copilot Studio Dataverse variables, Foundry Agent Service thread stores in Cosmos DB, custom implementations).
 - **Analytics** - Plan transcript retention, telemetry, and review processes before launch. Use **Translytical Task Flows** in Fabric to trigger actions directly from analytical reports.
 

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -184,18 +184,18 @@ Use this matrix to choose between Agent Framework Workflows, Logic Apps AI Agent
 
 ## Data Grounding Technology Comparison
 
-Side-by-side grounding options (Copilot connectors, AI Search, Fabric, Cosmos, PostgreSQL, SQL Server) by search mode, boundary, and best-fit workloads.
+Side-by-side grounding options (Copilot connectors, AI Search, Fabric, Cosmos, PostgreSQL, SQL Database Engine family) by search mode, boundary, and best-fit workloads.
 
-| Feature | **Copilot connectors** | **Azure AI Search** | **Microsoft Fabric** | **Cosmos DB** | **PostgreSQL** | **SQL Server 2025** |
+| Feature | **Copilot connectors** | **Azure AI Search** | **Microsoft Fabric** | **Cosmos DB** | **PostgreSQL** | **SQL Database Engine** (Azure SQL DB, SQL MI, SQL Server 2025, SQL database in Fabric) |
 |---------|---------------------|---------------------|----------------------|----------------|----------------|---------------------|
-| **Vector Search** | No (semantic index only) | ✅ Yes (IVF, HNSW) | ✅ Yes (Lakehouse via external tools) | ✅ Yes (IVF, HNSW, DiskANN) | ✅ Yes (pgvector, IVF) | ✅ Yes (DiskANN) |
+| **Vector Search** | No (semantic index only) | ✅ Yes (IVF, HNSW) | ✅ Yes (Lakehouse via external tools) | ✅ Yes (IVF, HNSW, DiskANN) | ✅ Yes (pgvector, IVF) | ✅ Yes (DiskANN, ANN Index Preview) |
 | **Hybrid Search** | No | ✅ Yes (vector + keyword) | ✅ Yes (SQL endpoint + external) | ✅ Yes | ✅ Yes | ✅ Yes |
-| **Data Boundary** | M365 tenant | Azure | Azure (OneLake) | Azure | Azure | On-premises or Azure |
-| **Index Target** | Microsoft Graph (connector ingestion) | Azure AI Search index / knowledge bases (agentic retrieval, preview) | Lakehouse Delta tables, Warehouse tables | Cosmos DB collection | PostgreSQL table | SQL Server table |
-| **Access Method** | Graph API (Copilot connector APIs) | REST API, SDKs (`2025-11-01-preview` for knowledge bases) | ADLS Gen2 APIs, SQL endpoint, Fabric Data Agents | SDKs, REST API | SQL, pgvector | T-SQL, VECTOR type |
-| **Best For** | M365-centric knowledge (Copilot, Search, Context IQ) | Azure-native RAG with ACL/label enforcement and agentic retrieval | Analytics data + unified data platform | Transactional + vector data | PostgreSQL workloads with AI | SQL Server workloads with AI |
-| **Licensing** | Included with M365 | Azure consumption (agentic retrieval preview on free tier quotas) | Fabric capacity (F2+) | Azure consumption | Azure consumption | SQL Server license |
-| **Status** | GA | GA (agentic retrieval preview) | GA (Platform), Preview (Data Agents) | GA | GA | Preview |
+| **Data Boundary** | M365 tenant | Azure | Azure (OneLake) | Azure | Azure | Azure SQL DB & SQL MI: Azure. SQL Server 2025: On-prem or Azure VM. SQL database in Fabric: Fabric. |
+| **Index Target** | Microsoft Graph (connector ingestion) | Azure AI Search index / knowledge bases (agentic retrieval, preview) | Lakehouse Delta tables, Warehouse tables | Cosmos DB collection | PostgreSQL table | SQL table (VECTOR column) |
+| **Access Method** | Graph API (Copilot connector APIs) | REST API, SDKs (`2025-11-01-preview` for knowledge bases) | ADLS Gen2 APIs, SQL endpoint, Fabric Data Agents | SDKs, REST API | SQL, pgvector | T-SQL, VECTOR type, VECTOR_DISTANCE, VECTOR_SEARCH |
+| **Best For** | M365-centric knowledge (Copilot, Search, Context IQ) | Azure-native RAG with ACL/label enforcement and agentic retrieval | Analytics data + unified data platform | Transactional + vector data | PostgreSQL workloads with AI | SQL workloads with AI — choose deployment by existing estate (cloud PaaS, lift-and-shift, on-prem, Fabric) |
+| **Licensing** | Included with M365 | Azure consumption (agentic retrieval preview on free tier quotas) | Fabric capacity (F2+) | Azure consumption | Azure consumption | Azure SQL DB/MI: Azure consumption. SQL Server 2025: SQL license. SQL in Fabric: Fabric capacity. |
+| **Status** | GA | GA (agentic retrieval preview) | GA (Platform), Preview (Data Agents) | GA | GA | VECTOR type GA. ANN index (DiskANN) Preview. |
 
 **Sources:**
 - [Microsoft 365 Copilot connectors overview](https://learn.microsoft.com/en-us/graph/connecting-external-content-connectors-overview) (Updated: 2025-07-21)
@@ -204,9 +204,11 @@ Side-by-side grounding options (Copilot connectors, AI Search, Fabric, Cosmos, P
 - [Microsoft Foundry (Azure) FAQ](https://learn.microsoft.com/en-us/azure/ai-foundry/faq?view=foundry-classic) (Updated: 2026-01-23)
 - [Cosmos DB Vector Search](https://learn.microsoft.com/en-us/azure/cosmos-db/vector-search) (Updated: 2025-09-25)
 - [Azure Database for PostgreSQL AI](https://learn.microsoft.com/en-us/azure/postgresql/azure-ai/generative-ai-overview) (Updated: 2026-01-20)
-- [SQL Server 2025 Vectors](https://learn.microsoft.com/en-us/sql/sql-server/ai/vectors?view=sql-server-ver17) (Updated: 2025-07-24)
+- [SQL Database Engine Vectors](https://learn.microsoft.com/en-us/sql/sql-server/ai/vectors?view=sql-server-ver17) — applies to SQL Server 2025, Azure SQL Database, Azure SQL MI, SQL database in Fabric (Updated: 2025-07-24)
+- [Azure SQL Database AI](https://learn.microsoft.com/en-us/azure/azure-sql/database/ai-artificial-intelligence-intelligent-applications) (Updated: 2026-02-06)
+- [SQL database in Fabric](https://learn.microsoft.com/en-us/fabric/database/sql/overview) (Updated: 2026-02-06)
 
-**Confidence Level:** High for GA technologies, Medium for SQL Server 2025 Preview
+**Confidence Level:** High for GA technologies (VECTOR type GA across SQL engine family), Medium for ANN Index (DiskANN) Preview
 
 ---
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -172,7 +172,7 @@ description: "Fast lookup table for Microsoft AI technologies"
 | **Unstructured Documents** | Vector search with chunking | Azure AI Search, Azure OpenAI Embeddings |
 | **Real-Time Transactional Data** | API-based grounding | API plugins, Functions, Logic Apps agent workflows |
 | **Multimodal Content** | Azure AI Content Understanding (Preview) | Process documents, images, audio, video with reasoning |
-| **Database Vectors** | AI-capable databases with managed embeddings | Azure Cosmos DB for NoSQL (standard setup: 3 × 1000 RU containers), PostgreSQL (GA), SQL Server 2025 (Preview) |
+| **Database Vectors** | AI-capable databases with managed embeddings | Azure Cosmos DB for NoSQL (standard setup: 3 × 1000 RU containers), PostgreSQL (GA), Azure SQL Database (GA), Azure SQL MI (GA), SQL Server 2025 (GA), SQL database in Fabric (GA). ANN indexes Preview across SQL Database Engine family. |
 | **Microsoft Fabric Platform** | Direct data access | Lakehouse (Delta tables), Warehouse (T-SQL), OneLake (ADLS Gen2 APIs), SQL analytics endpoint |
 | **Microsoft Fabric via Agent** | Conversational data layer | Fabric Data Agents (Preview) with Copilot Studio or Microsoft Foundry Agent Service |
 

--- a/docs/visual-framework.md
+++ b/docs/visual-framework.md
@@ -89,14 +89,22 @@ flowchart TD
     DataQ -->|No grounding| DirectDeploy
     
     VectorDB -->|Global scale NoSQL| CosmosDB[Cosmos DB<br/>IVF/HNSW/DiskANN]
-    VectorDB -->|Relational| PostgreSQL[PostgreSQL<br/>pgvector]
-    VectorDB -->|Enterprise SQL| SQLServer[SQL Server 2025<br/>VECTOR <i>Preview</i>]
+    VectorDB -->|Relational, OSS| PostgreSQL[PostgreSQL<br/>pgvector]
+    VectorDB -->|SQL Database Engine| SQLFamily{Where does<br/>SQL run?}
+    
+    SQLFamily -->|Cloud PaaS| AzureSQL[Azure SQL Database<br/>VECTOR type<br/>ANN Index <i>Preview</i>]
+    SQLFamily -->|Lift-and-shift PaaS| SQLMI[Azure SQL MI<br/>VECTOR type<br/>ANN Index <i>Preview</i>]
+    SQLFamily -->|On-prem / VM| SQLServer[SQL Server 2025<br/>VECTOR type<br/>ANN Index <i>Preview</i>]
+    SQLFamily -->|Fabric-native| SQLFabric[SQL database in Fabric<br/>VECTOR type<br/>ANN Index <i>Preview</i>]
     
     GraphConn --> DeployConfig
     AISearch --> DeployConfig
     CosmosDB --> DeployConfig
     PostgreSQL --> DeployConfig
+    AzureSQL --> DeployConfig
+    SQLMI --> DeployConfig
     SQLServer --> DeployConfig
+    SQLFabric --> DeployConfig
     Fabric --> DeployConfig
     DirectDeploy --> DeployConfig
     
@@ -129,7 +137,7 @@ flowchart TD
 ### Validation Summary
 {: .no_toc }
 
-**Last Validated:** January 2026
+**Last Validated:** February 2026
 
 #### UI-Based Agents (GA unless noted)
 {: .no_toc }
@@ -166,7 +174,10 @@ flowchart TD
 |------------|--------|--------------|
 | **Cosmos DB** | GA | IVF, HNSW, DiskANN algorithms [(docs)](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search) |
 | **PostgreSQL pgvector** | GA | Extension 0.7.0 [(docs)](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-use-pgvector) |
-| **SQL Server 2025 VECTOR** | Preview | Native type, float32/float16 [(docs)](https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type) |
+| **Azure SQL Database** | GA (ANN Index Preview) | Native VECTOR type, VECTOR_DISTANCE, DiskANN index, 1,998 dims, LangChain + Semantic Kernel integrations [(docs)](https://learn.microsoft.com/en-us/azure/azure-sql/database/ai-artificial-intelligence-intelligent-applications) |
+| **Azure SQL MI** | GA (ANN Index Preview) | Same SQL Database Engine; requires Always-up-to-date or SQL Server 2025 update policy [(docs)](https://learn.microsoft.com/en-us/sql/sql-server/ai/vectors?view=sql-server-ver17) |
+| **SQL Server 2025** | GA (ANN Index Preview) | Native VECTOR type, float32/float16, on-prem or VM [(docs)](https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type) |
+| **SQL database in Fabric** | GA (ANN Index Preview) | Fabric-native SQL with VECTOR type, same engine capabilities [(docs)](https://learn.microsoft.com/en-us/fabric/database/sql/overview) |
 
 ---
 
@@ -306,8 +317,13 @@ flowchart TD
     FileSearch -->|Copilot Studio| StudioKnowledge[Studio Knowledge Base<br/>Up to 1,000 files<br/>SharePoint or OneDrive]
     
     DB -->|Global scale, NoSQL| Cosmos{Vector algorithm?}
-    DB -->|Relational| Postgres[PostgreSQL with pgvector]
-    DB -->|Enterprise SQL| SQL[SQL Server 2025<br/>VECTOR Preview]
+    DB -->|Relational, OSS| Postgres[PostgreSQL with pgvector]
+    DB -->|SQL Database Engine| SQLFamily{Where does<br/>your SQL run?}
+    
+    SQLFamily -->|Cloud PaaS| AzureSQL[Azure SQL Database<br/>VECTOR type, DiskANN<br/>ANN Index Preview]
+    SQLFamily -->|Lift-and-shift PaaS| SQLMI[Azure SQL MI<br/>VECTOR type<br/>ANN Index Preview]
+    SQLFamily -->|On-prem / VM| SQL[SQL Server 2025<br/>VECTOR type<br/>ANN Index Preview]
+    SQLFamily -->|Fabric-native| SQLFabric[SQL database in Fabric<br/>VECTOR type<br/>ANN Index Preview]
     
     Cosmos -->|Flat index| CosmosIVF[Cosmos DB IVF]
     Cosmos -->|Graph-based| CosmosHNSW[Cosmos DB HNSW]
@@ -331,7 +347,10 @@ flowchart TD
     CosmosHNSW --> Platform
     CosmosDiskANN --> Platform
     Postgres --> Platform
+    AzureSQL --> Platform
+    SQLMI --> Platform
     SQL --> Platform
+    SQLFabric --> Platform
     Blob --> Platform
     HybridM365 --> Platform
     HybridAzure --> Platform
@@ -353,7 +372,10 @@ flowchart TD
     style CosmosHNSW fill:#004578,color:#fff
     style CosmosDiskANN fill:#004578,color:#fff
     style Postgres fill:#004578,color:#fff
+    style AzureSQL fill:#004578,color:#fff
+    style SQLMI fill:#004578,color:#fff
     style SQL fill:#004578,color:#fff
+    style SQLFabric fill:#8c5e00,color:#fff
     style FabricPlatform fill:#8c5e00,color:#fff
     style FabricAgent fill:#8c5e00,color:#fff
 ```
@@ -361,7 +383,7 @@ flowchart TD
 ### Validation Summary - Data Grounding Decision
 {: .no_toc }
 
-**Last Validated:** January 28, 2026
+**Last Validated:** February 6, 2026
 
 #### M365 Data Sources (GA)
 {: .no_toc }
@@ -399,7 +421,10 @@ flowchart TD
 |------------|--------|--------------|---------------|
 | **Cosmos DB Vector Search** | GA | IVF/HNSW/DiskANN algorithms, NoSQL & MongoDB vCore APIs | [Cosmos DB Vector Search](https://learn.microsoft.com/en-us/azure/cosmos-db/vector-database) |
 | **PostgreSQL pgvector** | GA | Extension version 0.7.0, HNSW/IVF indexes | [PostgreSQL Vector Search](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-use-pgvector) |
-| **SQL Server 2025 VECTOR** | Preview RC1 | Native VECTOR data type, float32 (1,998 dims)/float16 (3,996 dims) | [SQL Server Vector](https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type) |
+| **Azure SQL Database** | GA (ANN Index Preview) | Native VECTOR type, VECTOR_DISTANCE, DiskANN index, 1,998 dims, LangChain + Semantic Kernel connectors | [Azure SQL AI](https://learn.microsoft.com/en-us/azure/azure-sql/database/ai-artificial-intelligence-intelligent-applications) |
+| **Azure SQL Managed Instance** | GA (ANN Index Preview) | Same SQL Database Engine; requires Always-up-to-date or SQL Server 2025 update policy | [SQL MI Update Policy](https://learn.microsoft.com/en-us/azure/azure-sql/managed-instance/update-policy) |
+| **SQL Server 2025** | GA (ANN Index Preview) | Native VECTOR data type, float32 (1,998 dims)/float16 (3,996 dims) | [SQL Server Vector](https://learn.microsoft.com/en-us/sql/t-sql/data-types/vector-data-type) |
+| **SQL database in Fabric** | GA (ANN Index Preview) | Fabric-native SQL with VECTOR type, same engine as Azure SQL Database | [SQL database in Fabric](https://learn.microsoft.com/en-us/fabric/database/sql/overview) |
 
 #### Analytics Platform (GA with Preview features)
 {: .no_toc }


### PR DESCRIPTION
Add Azure SQL Database, Azure SQL Managed Instance, and SQL database in Fabric alongside SQL Server 2025 for vector search capabilities.

The VECTOR data type is a SQL Database Engine feature shared across all four products (GA, with ANN/DiskANN index in Preview).

Updated files:
- visual-framework.md: Both Mermaid diagrams + validation summaries
- decision-framework.md: Grounding (RAG) technology list
- quick-reference.md: Data Grounding Pattern table
- feature-comparison.md: Data Grounding Technology Comparison matrix

Addresses feedback to include Azure SQL, SQL MI, and SQL in Fabric as additional vector search options in the decision framework.