### PR TITLE
fix(docs): repair 8 broken doc URLs from link-checker run #25688551455

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We welcome contributions from developers and organizations worldwide! Our goal i
 - **Scenario contributions**: Add real-world use cases with validated technology recommendations
 - **Technology research**: Validate capabilities against official Microsoft Learn documentation
 - **Framework enhancements**: Improve BXT methodology, evaluation criteria, or implementation patterns
-- **Community engagement**: Participate in [discussions](https://github.com/microsoft/microsoft-ai-decision-framework/discussions), answer questions, share experiences
+- **Community engagement**: Participate in [issues](https://github.com/microsoft/Microsoft-AI-Decision-Framework/issues), answer questions, share experiences
 
 ## Philosophy: Right Technology, Right Context
 
@@ -141,7 +141,7 @@ Before submitting your PR, verify:
 
 ## Questions or Need Help?
 
-- **Documentation questions**: Create a [discussion](https://github.com/microsoft/microsoft-ai-decision-framework/discussions)
+- **Documentation questions**: Open an [issue](https://github.com/microsoft/Microsoft-AI-Decision-Framework/issues)
 - **Bug reports**: File an [issue](https://github.com/microsoft/microsoft-ai-decision-framework/issues)
 - **Feature requests**: File an [issue](https://github.com/microsoft/microsoft-ai-decision-framework/issues) with detailed description
 - **Security vulnerabilities**: See [SECURITY.md](SECURITY.md)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@
 
 This project uses [GitHub Issues](https://github.com/microsoft/microsoft-ai-decision-framework/issues) to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new Issue.
 
-For help and questions about using this framework, please use [GitHub Discussions](https://github.com/microsoft/microsoft-ai-decision-framework/discussions). Follow the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/) when participating in the forum.
+For help and questions about using this framework, please use [GitHub Issues](https://github.com/microsoft/Microsoft-AI-Decision-Framework/issues). Follow the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/) when participating in the forum.
 
 ## Microsoft Support Policy
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -159,7 +159,7 @@ This page provides comprehensive links to official Microsoft documentation, trai
 
 - **Copilot Studio**
   - [What's new in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/whats-new#october-2025)
-  - [Declarative agents](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/copilot-studio-declarative-agents)
+  - [Declarative agents](https://learn.microsoft.com/microsoft-365/copilot/extensibility/overview-declarative-agent)
   - [Custom engine agents overview](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/overview-custom-engine-agent)
   - [Copilot Studio documentation](https://learn.microsoft.com/en-us/microsoft-copilot-studio/)
   - [Computer Use (Preview)](https://learn.microsoft.com/en-us/microsoft-copilot-studio/computer-use)
@@ -181,8 +181,8 @@ This page provides comprehensive links to official Microsoft documentation, trai
 ### SDKs & Frameworks
 {: .no_toc }
 
-- **M365 Agents SDK**
-  - [Overview](https://learn.microsoft.com/en-us/microsoft-365/dev/m365-agents-sdk/overview)
+- **Microsoft Agent 365 SDK**
+  - [Microsoft Agent 365 SDK Overview](https://learn.microsoft.com/microsoft-agent-365/developer/agent-365-sdk)
   - [VS Code Toolkit](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
   - [Sample Gallery](https://github.com/microsoft/Agents)
 
@@ -260,10 +260,10 @@ This page provides comprehensive links to official Microsoft documentation, trai
 ### Learning Paths
 {: .no_toc }
 
-- [Microsoft 365 Copilot Extensibility Learning Path](https://learn.microsoft.com/en-us/training/paths/m365-copilot-extensibility/)
-- [Build Copilot Extensions](https://learn.microsoft.com/en-us/training/modules/build-copilot-extensions/)
+- [Microsoft 365 Copilot Extensibility Learning Path](https://learn.microsoft.com/training/paths/prepare-microsoft-365-copilot-extensibility/)
+- [Build Copilot Extensions](https://learn.microsoft.com/training/paths/build-foundation-extend-microsoft-365-copilot/)
 - [Azure AI Engineer Certification](https://learn.microsoft.com/en-us/certifications/azure-ai-engineer/)
-- [Semantic Kernel Learning Path](https://learn.microsoft.com/en-us/training/paths/develop-ai-agents-azure-openai-semantic-kernel-sdk/)
+- [Semantic Kernel Learning Path](https://learn.microsoft.com/training/paths/develop-ai-agents-azure-open-ai-semantic-kernel-sdk/)
 
 ### GitHub Repositories
 {: .no_toc }

--- a/docs/visual-framework.md
+++ b/docs/visual-framework.md
@@ -866,7 +866,7 @@ flowchart TD
 
 | Technology | Status | Capabilities | Documentation |
 |------------|--------|--------------|---------------|
-| **Copilot Studio** | Preview | Agent2Agent (A2A) decentralized mesh, Connected agents, child agents, handoffs | [Connected Agents](https://learn.microsoft.com/microsoft-copilot-studio/advanced-connected-agents) |
+| **Copilot Studio** | Preview | Agent2Agent (A2A) decentralized mesh, Connected agents, child agents, handoffs | [Connected Agents](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-add-other-agents) |
 | **Foundry Agent Service** | GA | Multi-agent workflows with orchestration patterns | [Agent Workflows](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow) |
 | **Fabric Data Agents** | Preview | Consumed by other agents for data grounding (NOT orchestrator) | [Fabric Integration](https://learn.microsoft.com/en-us/fabric/data-science/data-agent-microsoft-copilot-studio) |
 
@@ -885,7 +885,7 @@ flowchart TD
 
 | Technology | Status | Event Handling | Documentation |
 |------------|--------|----------------|---------------|
-| **Logic Apps AI Agent Workflows** | Preview | Event triggers + MCP Server (triggers SINGLE agent, NOT multi-agent orchestration) | [Logic Apps Workflows](https://learn.microsoft.com/azure/logic-apps/create-run-ai-agent-workflow) |
+| **Logic Apps AI Agent Workflows** | Preview | Event triggers + MCP Server (triggers SINGLE agent, NOT multi-agent orchestration) | [Logic Apps Workflows](https://learn.microsoft.com/en-us/azure/logic-apps/create-autonomous-agent-workflows) |
 | **Azure Functions + Agent Service** | GA | Event-driven single agent invocation (event routing, NOT coordination) | [Agent Service](https://learn.microsoft.com/azure/ai-foundry/responsible-ai/agents/transparency-note) |
 | **Event Grid + Foundry** | GA | Event routing to trigger agents independently (NOT orchestration) | [Azure Event Grid](https://learn.microsoft.com/azure/event-grid/) |
 


### PR DESCRIPTION
Repairs the 8 broken documentation URLs surfaced by Documentation Link Checker run #25688551455 (Issue #28). Auto-fix PR #29 covered the 2 Azure pricing locale URLs; this PR handles the remaining 8.

All replacements are URL-only (plus minimal link-text rewrites where a product was renamed or a destination changed). No prose, structural, or formatting changes elsewhere.

## Replacements

### `docs/visual-framework.md`
- **L869** `[Connected Agents]` → `https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-add-other-agents`
  - The `advanced-connected-agents` page was removed. The canonical "Add other agents overview" page now covers connected agents, child agents, and handoffs.
- **L888** `[Logic Apps Workflows]` → `https://learn.microsoft.com/en-us/azure/logic-apps/create-autonomous-agent-workflows`
  - `create-run-ai-agent-workflow` split into autonomous and conversational variants. The row's context (event triggers + MCP Server, single agent) matches the autonomous variant.

### `docs/resources.md`
- **L162** `[Declarative agents]` → `https://learn.microsoft.com/microsoft-365/copilot/extensibility/overview-declarative-agent`
- **L185** `[Overview]` → `[Microsoft Agent 365 SDK Overview](https://learn.microsoft.com/microsoft-agent-365/developer/agent-365-sdk)` (and updated section header from "M365 Agents SDK" to "Microsoft Agent 365 SDK" to match the renamed product).
- **L263** `[Microsoft 365 Copilot Extensibility Learning Path]` → `https://learn.microsoft.com/training/paths/prepare-microsoft-365-copilot-extensibility/`
- **L264** `[Build Copilot Extensions]` → `https://learn.microsoft.com/training/paths/build-foundation-extend-microsoft-365-copilot/` (the original module was retired; the foundation path covers the same material).
- **L266** `[Semantic Kernel Learning Path]` → `https://learn.microsoft.com/training/paths/develop-ai-agents-azure-open-ai-semantic-kernel-sdk/` (slug typo: `azure-openai` → `azure-open-ai`).

### `CONTRIBUTING.md` and `SUPPORT.md`
Repo has GitHub Discussions disabled (verified via `gh repo view`), so all Discussions links 404. Redirected to Issues:
- **CONTRIBUTING.md L14** `[discussions](.../discussions)` → `[issues](.../issues)`
- **CONTRIBUTING.md L144** `[discussion](.../discussions)` → `Open an [issue](.../issues)`
- **SUPPORT.md L7** `[GitHub Discussions](.../discussions)` → `[GitHub Issues](.../issues)`

Closes #28
