### PR TITLE
ci: bump Pages build to Ruby 3.4 to fix sass-embedded native build

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.4'
           bundler-cache: true
           cache-version: 0
 


### PR DESCRIPTION
## Problem

The **Deploy Jekyll site to Pages** workflow failed on `main` after #36 merged ([failed run](https://github.com/microsoft/Microsoft-AI-Decision-Framework/actions/runs/27306142390/job/80664359599)).

Root cause is in the `Setup Ruby` step, not our content. The workflow pinned `ruby-version: '3.1'`. Ruby 3.1 is end-of-life and ships an older `json` gem that lacks `JSON::Fragment`. During `bundle install`, `sass-embedded 1.100.0` (pulled in transitively via `jekyll-sass-converter`) builds a native extension whose Rakefile requires `JSON::Fragment`, so the build aborts:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
NameError: uninitialized constant JSON::Fragment
An error occurred while installing sass-embedded (1.100.0), and Bundler cannot continue.
```

## Fix

Bump `ruby/setup-ruby` to `ruby-version: '3.4'` (current stable). No `.ruby-version` file or committed `Gemfile.lock` exists, so this is the only place the toolchain version is pinned. All other actions in the workflow are already current (`checkout@v4`, `setup-node@v4`, `configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`).

## Validation

Reproduced and validated locally with Docker against the exact `Gemfile`:
- Ruby 3.4 clean `bundle install` succeeds (the step that failed in CI).
- `JEKYLL_ENV=production bundle exec jekyll build` succeeds end to end.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>