### PR TITLE
fix(site): load the on-this-page rail as a static asset

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -36,12 +36,11 @@
     mermaid.run({ querySelector: '.mermaid' });
   });
 </script>
-<script>
-  // "On this page" rail — see _includes/page_toc.js
-  document.addEventListener('DOMContentLoaded', () => {
-    {% include page_toc.js %}
-  });
-</script>
+<!-- "On this page" rail.
+     Loaded as a static asset rather than inlined via {% raw %}{% include %}{% endraw %}: the built HTML is
+     served with newlines stripped, which would collapse the script onto one
+     line and let its first // comment swallow the rest of the file. -->
+<script src="{{ '/assets/js/page-toc.js' | relative_url }}" defer></script>
 <style>
   /* Hide the theme footer inside the sidebar */
   body > .side-bar > footer.site-footer {

--- a/assets/js/page-toc.js
+++ b/assets/js/page-toc.js
@@ -1,7 +1,12 @@
 // Builds the "On this page" rail from the headings the page already has.
 // Generated rather than authored so every page gets one, including those with
 // no kramdown {:toc} block, and so it stays correct when headings change.
+//
+// Loaded as a static asset with `defer`. It must not be inlined into the page:
+// the built HTML is served with newlines stripped, which would collapse this
+// file onto a single line and let the first // comment swallow all of it.
 (() => {
+  const build = () => {
   const content = document.querySelector('#main-content');
   if (!content) return;
 
@@ -92,4 +97,13 @@
   addEventListener('scroll', schedule, { passive: true });
   addEventListener('resize', schedule, { passive: true });
   update();
+  };
+
+  // `defer` means the DOM is normally ready by now; the guard keeps this
+  // correct if the tag is ever moved or the attribute dropped.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', build, { once: true });
+  } else {
+    build();
+  }
 })();


### PR DESCRIPTION
The built HTML is served with newlines stripped — the entire `<head>` arrives as a single line. Inlining `page_toc.js` through `{% raw %}{% include %}{% endraw %}` collapsed the script onto one line, so its first `//` comment commented out the rest of the file.

**Production impact:** the `On this page` rail never rendered, and since the script also never added `.has-page-toc`, the two-column grid never engaged — leaving prose at **235 characters per line at 1920px instead of 199**.

**Fix:** move the script to `assets/js/page-toc.js` and load it with `<script defer>`. Static assets are copied verbatim, so it is never passed through Liquid or flattened into the page. Adds a `readyState` guard in case the tag is moved or `defer` dropped.

Verified across six pages at four widths: rail present, `.has-page-toc` applied, grid engaged, `.no_toc` honoured, scroll-spy tracking correctly in both directions.